### PR TITLE
SOLVED: Issue with Kabsch alignment

### DIFF
--- a/lib/alignment.c
+++ b/lib/alignment.c
@@ -534,9 +534,9 @@ void correct_rmsd(alignments *new_align, traj *Trajectory, alignments *align, in
                 msd_added += v[j] * v[j];
             }
             if (align->rsd == 0) {// no rsd, standard rmsd
-                new_align->rmsd_mat[knt] = sqrt(align->rmsd_mat[knt] * align->rmsd_mat[knt] - msd_removed / cgnum + msd_added / cgnum);
+                new_align->rmsd_mat[knt] = sqrt(fabs(align->rmsd_mat[knt] * align->rmsd_mat[knt] - msd_removed / cgnum + msd_added / cgnum));
             } else if (align->rsd == 1) {
-                new_align->rmsd_mat[knt] = sqrt(align->rmsd_mat[knt] * align->rmsd_mat[knt] - msd_removed + msd_added);
+                new_align->rmsd_mat[knt] = sqrt(fabs(align->rmsd_mat[knt] * align->rmsd_mat[knt] - msd_removed + msd_added));
             }
             knt += 1;
         }
@@ -587,7 +587,7 @@ double correct_rmsd_two_frames(traj *Trajectory, double u[9], double com_ref[3],
         msd_added += v[j] * v[j];
     }
     // no rsd, standard rmsd
-    rmsd = sqrt(prev_rmsd * prev_rmsd - msd_removed / cgnum + msd_added / cgnum);
+    rmsd = sqrt(fabs(prev_rmsd * prev_rmsd - msd_removed / cgnum + msd_added / cgnum));
     //} else if (prev_align->rsd == 1) {
     //    rmsd = sqrt(prev_rmsd * prev_rmsd - msd_removed + msd_added);
     //}


### PR DESCRIPTION
This pull request solves the issue I found when computing the Kabsch alignment of two nearly identical structures. I added an absolute value to the calculation of the RMSD to prevent the generation of very small negative values. 

When two structures are found to be identical by the program, the value `align->rmsd_mat[knt]*align->rmsd_mat[knt]` is equal to zero. If `msd_removed` (found at 10^-29 for identical structures) is greater than `msd_added` (found at 10^-30 for identical structures), the overall result is negative so the RMSD cannot be calculated.

This update yields a very small value of RMSD even to nearly identical structures, allowing the computation of Kabsch alignment.

I corrected the function for all clustering criterions.